### PR TITLE
fix currentValue becoming undefined on reset

### DIFF
--- a/tiny-date-picker.js
+++ b/tiny-date-picker.js
@@ -135,7 +135,7 @@ function TinyDatePicker(input, options) {
     }
 
     input.value = date ? opts.format(date) : '';
-    currentValue = date;
+    currentValue = opts.parse(date || '');
     setDate(date);
     hide();
 


### PR DESCRIPTION
I stumbled across this issue after using v1.4 in a project.

*Expected Behaviour*
- click in input to open date picker
- click reset
- click in input opens date picker

*Actual Behaviour*
- click in input to open date picker
- click reset
- click in input throws exception -> currentValue is undefined


I don’t know if this is the correct place to fix this, but it works reliably with predictable outcome.