### PR TITLE
feat: Add detection for touchend events

### DIFF
--- a/tiny-date-picker.js
+++ b/tiny-date-picker.js
@@ -51,6 +51,10 @@ function TinyDatePicker(input, opts) {
       bufferShow();
     }
   });
+  on('touchend', input, function (e) {
+    bufferShow();
+    e.preventDefault();
+  });
   on('focus', input, bufferShow);
   on('input', input, tryUpdateDate);
 
@@ -189,6 +193,11 @@ function showCalendar(context) {
 
   // Prevent clicks on the wrapper's children from closing the modal
   on('mousedown', el, function (e) {
+    if (e.target !== el && e.target.tagName !== 'A') {
+      e.preventDefault();
+    }
+  });
+  on('touchend', el, function (e) {
     if (e.target !== el && e.target.tagName !== 'A') {
       e.preventDefault();
     }

--- a/tiny-date-picker.js
+++ b/tiny-date-picker.js
@@ -52,12 +52,14 @@ function TinyDatePicker(input, opts) {
     }
   });
   on('touchend', input, function () {
-    if (context.inputFocused()) {   // discovered that the problem on iOS Safari was not with document.activeElement itself,
-                                    // but with how context.inputFocused() was being set below.
-      bufferShow();                 // iOS safari does catch some mousedown events, but doesn't do so on input fields.
-                                    // For example, if you're forced into debugging with alert windows, it will intercept a
-                                    // mousedown event when you click the "OK" button..
-    }
+                                  // "input === document.activeElement" returns false on iOS Safari, but a few
+                                  // ms later it becomes true. Not sure of a good solution. Another thing
+                                  // that works is to return the actual document.activeElement instead of doing
+                                  // a comparison. Waiting for a bit with setTimeout seems like a bad idea..
+                                  // So just removed the check for focus altogether as tabs don't usually matter on touch devices.
+      bufferShow();               // iOS Safari does catch some mousedown events, but doesn't do so on input fields.
+                                  // For example, if you're forced into debugging with alert windows, it will intercept a
+                                  // mousedown event when you click the "OK" button..
   });
   on('focus', input, bufferShow);
   on('input', input, tryUpdateDate);
@@ -86,7 +88,7 @@ function buildContext(input, opts) {
       return isNaN(date) ? now() : date;
     },
     inputFocused: function() {
-      return document.activeElement;    // Removed 'input ===' as it doesn't work on iOS Safari. This works fine on other browsers too though.
+      return input === document.activeElement;
     },
     onChange: function (date, silent) {
       if (date && !inRange(context, date)) {
@@ -205,12 +207,6 @@ function showCalendar(context) {
     }
   });
   on('touchend', el, function (e) {
-    // if (e.target !== el) {
-    //     alert("They're not equal.");
-    // }
-    // if (e.target.tagName !== 'A') {
-    //     alert("It's not an A.");
-    // }
     if (e.target !== el && e.target.tagName !== 'A') {
       e.preventDefault();           // preventDefault() alone doesn't stop the modal from closing on iOS Safari..
       e.stopPropagation();          // Also, adding stopPropagation() here intercepts clicks in spacing around months modal.

--- a/tiny-date-picker.js
+++ b/tiny-date-picker.js
@@ -198,14 +198,22 @@ function showCalendar(context) {
   // Prevent clicks on the wrapper's children from closing the modal
   on('mousedown', el, function (e) {
     if (e.target !== el && e.target.tagName !== 'A') {
-        e.preventDefault();         // on chrome and firefox clicking whitespace around months before any date is set
-                                    // causes a problem, but adding stopPropagation() here doesn't prevent it..
+        e.preventDefault();         // on chrome and firefox, clicking whitespace around months
+                                    // causes a nasty problem but adding stopPropagation() here doesn't prevent it..
+                                    // So i added a check directly to the dp-month click event handler.
+                                    // You may wish to do something a little prettier :-).
     }
   });
   on('touchend', el, function (e) {
+    // if (e.target !== el) {
+    //     alert("They're not equal.");
+    // }
+    // if (e.target.tagName !== 'A') {
+    //     alert("It's not an A.");
+    // }
     if (e.target !== el && e.target.tagName !== 'A') {
-      e.stopPropagation();          // preventDefault() alone doesn't stop the modal from closing on iOS Safari..
-      e.preventDefault();           // Also, adding stopPropagation() here intercepts clicks in spacing around months modal.
+      e.preventDefault();           // preventDefault() alone doesn't stop the modal from closing on iOS Safari..
+      e.stopPropagation();          // Also, adding stopPropagation() here intercepts clicks in spacing around months modal.
     }
   });
 
@@ -246,9 +254,11 @@ function showCalendar(context) {
   });
 
   on('click', /dp-month/, el, function(e) {
-    context.currentDate.setMonth(parseInt(e.target.getAttribute('data-month')));
-    render(calHtml, context);
-    context.onSelectMonth(context);
+    if (e.target.tagName === 'A'){  // ignore irrelevant clicks in whitespace around month modal
+      context.currentDate.setMonth(parseInt(e.target.getAttribute('data-month')));
+      render(calHtml, context);
+      context.onSelectMonth(context);
+    }
   });
 
   on('click', /dp-cal-year/, el, function () {


### PR DESCRIPTION
Adding touchend event detection allowed it to work on an old iPad running iOS 9.35 as it doesn't detect mousedown on input elements. Not sure if they fixed this in more recent iOS's. Also found a bug reproducable by clicking the whitespace in the months selection modal before a date has been selected. Just worked around that by only accepting A element click targets in the dp-month click event.. Thanks for sharing this, it's really great.

Edit: Just thought to check the demo and it works correctly on that device.. Not sure why, will have to look closer at it..

Edit2: 
Ok, the date picker was not popping up because i'm using [fastclick](https://github.com/ftlabs/fastclick) to avoid the 300ms delay on some touch devices. Without it, 'mousedown' works on this version of safari too (but then there's another problem where post date-entry one can't break focus on the input field, except by clicking on another input element..). However, with the changes, it works alongside fastclick and tapping anywhere on the document also blurs the input field as usual.

