### PR TITLE
document.documentElement.scrollTop does not work everywhere

### DIFF
--- a/src/mode/dropdown-mode.js
+++ b/src/mode/dropdown-mode.js
@@ -24,7 +24,7 @@ export default function DropdownMode(input, emit, opts) {
 
 function autoPosition(input, dp) {
   var inputPos = input.getBoundingClientRect();
-  var docEl = document.documentElement;
+  var docEl = document.body.scrollTop !== 0 ? document.body : document.documentElement;
 
   adjustCalY(dp, inputPos, docEl);
   adjustCalX(dp, inputPos, docEl);


### PR DESCRIPTION
document.documentElement does not work on different browsers like safari on ios. so the dropdown broke for me on those browsers when the user scrolled the page.

i added a check if document.body.scrollTop has an value, if so use document.body else use document.documentElement.