### PR TITLE
Allow options for DateRangePicker instance

### DIFF
--- a/dist/date-range-picker.js
+++ b/dist/date-range-picker.js
@@ -1216,7 +1216,8 @@
    * @param {HTMLElement} input The input associated with the datepicker
    * @returns {DateRangePickerInst}
    */
-  function DateRangePicker(container) {
+  function DateRangePicker(container, opts) {
+    opts = opts || {};
     var emitter = Emitter();
     var root = renderInto(container);
     var hoverDate;
@@ -1224,15 +1225,17 @@
       start: undefined,
       end: undefined,
     };
-    var start = TinyDatePicker(root.querySelector('.dr-cal-start'), {
+    opts.startOpts = cp(opts.startOpts || {}, {
       mode: 'dp-permanent',
       dateClass: dateClass,
     });
-    var end = TinyDatePicker(root.querySelector('.dr-cal-end'), {
+    var start = TinyDatePicker(root.querySelector('.dr-cal-start'), opts.startOpts);
+    opts.endOpts = cp(opts.endOpts || {}, {
       mode: 'dp-permanent',
       hilightedDate: shiftMonth(start.state.hilightedDate, 1),
       dateClass: dateClass,
     });
+    var end = TinyDatePicker(root.querySelector('.dr-cal-end'), opts.endOpts);
     var handlers = {
       'statechange': onStateChange,
       'select': dateSelected,

--- a/dist/date-range-picker.js
+++ b/dist/date-range-picker.js
@@ -134,6 +134,47 @@
   }
 
   /**
+   * @file Utility functions for function manipulation.
+   */
+
+  /**
+   * bufferFn buffers calls to fn so they only happen ever ms milliseconds
+   *
+   * @param {number} ms number of milliseconds
+   * @param {function} fn the function to be buffered
+   * @returns {function}
+   */
+  function bufferFn(ms, fn) {
+    var timeout = undefined;
+    return function () {
+      clearTimeout(timeout);
+      timeout = setTimeout(fn, ms);
+    };
+  }
+
+  /**
+   * noop is a function which does nothing at all.
+   */
+  function noop() { }
+
+  /**
+   * copy properties from object o2 to object o1.
+   *
+   * @params {Object} o1
+   * @params {Object} o2
+   * @returns {Object}
+   */
+  function cp(o1, o2) {
+    o2 = o2 || {};
+
+    for (var key in o2) {
+      o1[key] = o2[key];
+    }
+
+    return o1;
+  }
+
+  /**
    * @file Responsible for sanitizing and creating date picker options.
    */
 
@@ -213,16 +254,6 @@
     return function (dt, dp) {
       return inRange(dt, dp) && opts.min <= dt && opts.max >= dt;
     };
-  }
-
-  function cp(o1, o2) {
-    o2 = o2 || {};
-
-    for (var key in o2) {
-      o1[key] = o2[key];
-    }
-
-    return o1;
   }
 
   /**
@@ -606,30 +637,6 @@
 
     return result;
   }
-
-  /**
-   * @file Utility functions for function manipulation.
-   */
-
-  /**
-   * bufferFn buffers calls to fn so they only happen ever ms milliseconds
-   *
-   * @param {number} ms number of milliseconds
-   * @param {function} fn the function to be buffered
-   * @returns {function}
-   */
-  function bufferFn(ms, fn) {
-    var timeout = undefined;
-    return function () {
-      clearTimeout(timeout);
-      timeout = setTimeout(fn, ms);
-    };
-  }
-
-  /**
-   * noop is a function which does nothing at all.
-   */
-  function noop() { }
 
   /**
    * @file Defines the base date picker behavior, overridden by various modes.

--- a/dist/tiny-date-picker.js
+++ b/dist/tiny-date-picker.js
@@ -134,6 +134,47 @@
   }
 
   /**
+   * @file Utility functions for function manipulation.
+   */
+
+  /**
+   * bufferFn buffers calls to fn so they only happen ever ms milliseconds
+   *
+   * @param {number} ms number of milliseconds
+   * @param {function} fn the function to be buffered
+   * @returns {function}
+   */
+  function bufferFn(ms, fn) {
+    var timeout = undefined;
+    return function () {
+      clearTimeout(timeout);
+      timeout = setTimeout(fn, ms);
+    };
+  }
+
+  /**
+   * noop is a function which does nothing at all.
+   */
+  function noop() { }
+
+  /**
+   * copy properties from object o2 to object o1.
+   *
+   * @params {Object} o1
+   * @params {Object} o2
+   * @returns {Object}
+   */
+  function cp(o1, o2) {
+    o2 = o2 || {};
+
+    for (var key in o2) {
+      o1[key] = o2[key];
+    }
+
+    return o1;
+  }
+
+  /**
    * @file Responsible for sanitizing and creating date picker options.
    */
 
@@ -213,16 +254,6 @@
     return function (dt, dp) {
       return inRange(dt, dp) && opts.min <= dt && opts.max >= dt;
     };
-  }
-
-  function cp(o1, o2) {
-    o2 = o2 || {};
-
-    for (var key in o2) {
-      o1[key] = o2[key];
-    }
-
-    return o1;
   }
 
   /**
@@ -606,30 +637,6 @@
 
     return result;
   }
-
-  /**
-   * @file Utility functions for function manipulation.
-   */
-
-  /**
-   * bufferFn buffers calls to fn so they only happen ever ms milliseconds
-   *
-   * @param {number} ms number of milliseconds
-   * @param {function} fn the function to be buffered
-   * @returns {function}
-   */
-  function bufferFn(ms, fn) {
-    var timeout = undefined;
-    return function () {
-      clearTimeout(timeout);
-      timeout = setTimeout(fn, ms);
-    };
-  }
-
-  /**
-   * noop is a function which does nothing at all.
-   */
-  function noop() { }
 
   /**
    * @file Defines the base date picker behavior, overridden by various modes.

--- a/src/date-picker-options.js
+++ b/src/date-picker-options.js
@@ -3,6 +3,7 @@
  */
 
 import {now, shiftYear, dateOrParse} from './lib/date-manip';
+import {cp} from './lib/fns';
 
 var english = {
   days: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
@@ -80,14 +81,4 @@ function makeInRangeFn(opts) {
   return function (dt, dp) {
     return inRange(dt, dp) && opts.min <= dt && opts.max >= dt;
   };
-}
-
-function cp(o1, o2) {
-  o2 = o2 || {};
-
-  for (var key in o2) {
-    o1[key] = o2[key];
-  }
-
-  return o1;
 }

--- a/src/date-range-picker.js
+++ b/src/date-range-picker.js
@@ -2,6 +2,7 @@
 import TDP from './index';
 import Emitter from './lib/emitter';
 import {shiftMonth, datesEq} from './lib/date-manip';
+import {cp} from './lib/fns';
 
 export var TinyDatePicker = TDP;
 
@@ -29,7 +30,8 @@ export var TinyDatePicker = TDP;
  * @param {HTMLElement} input The input associated with the datepicker
  * @returns {DateRangePickerInst}
  */
-export function DateRangePicker(container) {
+export function DateRangePicker(container, opts) {
+  opts = opts || {};
   var emitter = Emitter();
   var root = renderInto(container);
   var hoverDate;
@@ -37,15 +39,17 @@ export function DateRangePicker(container) {
     start: undefined,
     end: undefined,
   };
-  var start = TDP(root.querySelector('.dr-cal-start'), {
+  opts.startOpts = cp(opts.startOpts || {}, {
     mode: 'dp-permanent',
     dateClass: dateClass,
   });
-  var end = TDP(root.querySelector('.dr-cal-end'), {
+  var start = TDP(root.querySelector('.dr-cal-start'), opts.startOpts);
+  opts.endOpts = cp(opts.endOpts || {}, {
     mode: 'dp-permanent',
     hilightedDate: shiftMonth(start.state.hilightedDate, 1),
     dateClass: dateClass,
   });
+  var end = TDP(root.querySelector('.dr-cal-end'), opts.endOpts);
   var handlers = {
     'statechange': onStateChange,
     'select': dateSelected,

--- a/src/lib/fns.js
+++ b/src/lib/fns.js
@@ -21,3 +21,20 @@ export function bufferFn(ms, fn) {
  * noop is a function which does nothing at all.
  */
 export function noop() { }
+
+/**
+ * copy properties from object o2 to object o1.
+ *
+ * @params {Object} o1
+ * @params {Object} o2
+ * @returns {Object}
+ */
+export function cp(o1, o2) {
+  o2 = o2 || {};
+
+  for (var key in o2) {
+    o1[key] = o2[key];
+  }
+
+  return o1;
+}


### PR DESCRIPTION
Options can now be passed to the DateRangePicker, as per the doc: 

> Any options that you would have passed to TinyDatePicker can be passed to the DateRangePicker, but with a twist:

```javascript
DateRangePicker('.cls', {
  startOpts: {}, // The options passed to the start date picker
  endOpts: {}, // The options passed to the end date picker
});
```