### PR TITLE
#94 - permanent-mode destroy should not be a noop

### DIFF
--- a/src/mode/permanent-mode.js
+++ b/src/mode/permanent-mode.js
@@ -8,7 +8,6 @@ export default function PermanentMode(root, emit, opts) {
   var dp = BaseMode(root, emit, opts);
 
   dp.close = noop;
-  dp.destroy = noop;
   dp.updateInput = noop;
   dp.shouldFocusOnRender = opts.shouldFocusOnRender;
 


### PR DESCRIPTION
Permanent mode destroy should not be overridden, `destroy()` in base mode will handle closing the UI and removing input event handlers. We dont need to override `destroy()` because we have already overridden `close()`