### PR TITLE
BaseMode's render returns if no dp.el.firstChild

### DIFF
--- a/dist/tiny-date-picker.js
+++ b/dist/tiny-date-picker.js
@@ -758,7 +758,7 @@
       },
 
       render: function () {
-        if (!dp.el) {
+        if (!dp.el || !dp.el.firstChild) {
           return;
         }
 


### PR DESCRIPTION
Occasionally, after about 8 instances of of the datepicker, the firstChild is undefined and crashes the datepicker. Changing "if (!dp.el)" to "if (!dp.el || !dp.el.firstChild)" fixes this issue.