### PR TITLE
add a window check in case of non-browser context

### DIFF
--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -31,6 +31,7 @@ export function on(evt, el, handler) {
 export var CustomEvent = shimCustomEvent();
 
 function shimCustomEvent() {
+  if(typeof window === 'undefined') {return;}
   var CustomEvent = window.CustomEvent;
 
   if (typeof CustomEvent !== 'function') {


### PR DESCRIPTION
This would fix a use case for us where we're bringing in tiny-date-picker into a lib which can be built by react / angular apps using ssr.